### PR TITLE
reintroduce lazy download

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-ffmperative/bin/ffmp filter=lfs diff=lfs merge=lfs -text

--- a/ffmperative/__init__.py
+++ b/ffmperative/__init__.py
@@ -9,12 +9,14 @@ from sys import argv
 
 from . import tools as t
 from .prompts import MAIN_PROMPT
+from .utils import download_ffmp
 from .tool_mapping import generate_tools_mapping
 from .interpretor import evaluate, extract_function_calls
 
 tools = generate_tools_mapping()
 
 def run_local(prompt):
+    download_ffmp()
     ffmp_path = pkg_resources.resource_filename('ffmperative', 'bin/ffmp')
     safe_prompt = shlex.quote(prompt)
     command = '{} -p "{}"'.format(ffmp_path, safe_prompt)

--- a/ffmperative/bin/.gitignore
+++ b/ffmperative/bin/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/ffmperative/bin/ffmp
+++ b/ffmperative/bin/ffmp
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f73559384e1a596ce25ab21de650c74e9ef7cef4f73e141e53ccc5ace177eefe
-size 1612975750

--- a/ffmperative/utils.py
+++ b/ffmperative/utils.py
@@ -7,6 +7,17 @@ import subprocess
 
 from pathlib import Path
 
+def download_ffmp():
+    ffmp_path = os.path.join(os.path.dirname(__file__), 'bin', 'ffmp')
+    if not os.path.exists(ffmp_path):
+        print("Downloading ffmp...")
+        model_url = "https://remyx.ai/assets/ffmperative/v0.0.7/ffmp"
+        response = requests.get(model_url, stream=True)
+        with open(ffmp_path, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+        print("Download complete.")
+
 def extract_and_encode_frame(video_path):
     # Get the duration of the video
     probe = ffmpeg.probe(video_path)

--- a/ffmperative/utils.py
+++ b/ffmperative/utils.py
@@ -8,7 +8,14 @@ import subprocess
 from pathlib import Path
 
 def download_ffmp():
-    ffmp_path = os.path.join(os.path.dirname(__file__), 'bin', 'ffmp')
+    bin_dir = os.path.join(os.path.dirname(__file__), 'bin')
+    ffmp_path = os.path.join(bin_dir, 'ffmp')
+
+    # Create the 'bin/' directory if it does not exist
+    if not os.path.exists(bin_dir):
+        os.makedirs(bin_dir, exist_ok=True)
+
+    # Download ffmp file if it does not exist
     if not os.path.exists(ffmp_path):
         print("Downloading ffmp...")
         model_url = "https://remyx.ai/assets/ffmperative/v0.0.7/ffmp"

--- a/ffmperative/utils.py
+++ b/ffmperative/utils.py
@@ -18,7 +18,7 @@ def download_ffmp():
     # Download ffmp file if it does not exist
     if not os.path.exists(ffmp_path):
         print("Downloading ffmp...")
-        model_url = "https://remyx.ai/assets/ffmperative/v0.0.7/ffmp"
+        model_url = "https://remyx.ai/assets/ffmperative/0.0.7/ffmp"
         response = requests.get(model_url, stream=True)
         with open(ffmp_path, 'wb') as f:
             for chunk in response.iter_content(chunk_size=8192):

--- a/setup.py
+++ b/setup.py
@@ -7,25 +7,14 @@ from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
-version = "0.0.7"
 
 def read_requirements(file):
     with open(file) as f:
         return [line.strip() for line in f if line.strip() and not line.startswith('#')]
 
-class CustomInstall(install):
-    def run(self):
-        # Ensuring the bin/ directory exists
-        bin_dir = os.path.join(self.install_lib, 'ffmperative', 'bin')
-        os.makedirs(bin_dir, exist_ok=True)
-
-        # Call the standard install command
-        install.run(self)
-
-
 setup(
     name="ffmperative",
-    version=version,
+    version="0.0.7",
     packages=find_packages(),
     include_package_data=True,
     install_requires=read_requirements((this_directory / 'requirements.txt')),
@@ -33,9 +22,6 @@ setup(
         "console_scripts": [
             "ffmperative=ffmperative.cli:main",
         ],
-    },
-    cmdclass={
-        'install': CustomInstall,
     },
     long_description=long_description,
     long_description_content_type='text/markdown'

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,58 @@
+import os
+import requests
 from setuptools import setup, find_packages
+from setuptools.command.install import install
 
 # read the contents of your README file
 from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text()
 
+version = "0.0.7"
+
 def read_requirements(file):
     with open(file) as f:
         return [line.strip() for line in f if line.strip() and not line.startswith('#')]
 
+class CustomInstall(install):
+    def run(self):
+        # Ensuring the bin/ directory exists
+        bin_dir = os.path.join(self.install_lib, 'ffmperative', 'bin')
+        os.makedirs(bin_dir, exist_ok=True)
+
+        # Download the model
+        self.download_model(bin_dir)
+
+        # Call the standard install command
+        install.run(self)
+
+    @staticmethod
+    def download_model(bin_dir):
+        model_url = f"https://remyx.ai/assets/ffmperative/{version}/ffmp"
+        target_path = os.path.join(bin_dir, 'ffmp')
+
+        if not os.path.exists(target_path):
+            print("Downloading model assets...")
+            response = requests.get(model_url, stream=True)
+            with open(target_path, 'wb') as f:
+                for chunk in response.iter_content(chunk_size=8192):
+                    f.write(chunk)
+            print("Download complete.")
+        return target_path
+
 setup(
     name="ffmperative",
-    version="0.0.7",
+    version=version,
     packages=find_packages(),
     include_package_data=True,
-    package_data={
-        'ffmperative': ['bin/ffmp'],
-    },
     install_requires=read_requirements((this_directory / 'requirements.txt')),
     entry_points={
         "console_scripts": [
             "ffmperative=ffmperative.cli:main",
         ],
+    },
+    cmdclass={
+        'install': CustomInstall,
     },
     long_description=long_description,
     long_description_content_type='text/markdown'

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import os
-import requests
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
@@ -20,25 +19,9 @@ class CustomInstall(install):
         bin_dir = os.path.join(self.install_lib, 'ffmperative', 'bin')
         os.makedirs(bin_dir, exist_ok=True)
 
-        # Download the model
-        self.download_model(bin_dir)
-
         # Call the standard install command
         install.run(self)
 
-    @staticmethod
-    def download_model(bin_dir):
-        model_url = f"https://remyx.ai/assets/ffmperative/{version}/ffmp"
-        target_path = os.path.join(bin_dir, 'ffmp')
-
-        if not os.path.exists(target_path):
-            print("Downloading model assets...")
-            response = requests.get(model_url, stream=True)
-            with open(target_path, 'wb') as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
-            print("Download complete.")
-        return target_path
 
 setup(
     name="ffmperative",


### PR DESCRIPTION
To make it easier to package for pypi, we need to remain under the 60 MB per file upload constraint. We need to reintroduce lazy downloading to avoid the `ffmp` binary to be packaged. 

Lazy download on the first call significantly reduces package size.