### PR TITLE
Install Outrider — weekly arXiv → draft PR scout

### DIFF
--- a/.github/workflows/outrider.yml
+++ b/.github/workflows/outrider.yml
@@ -1,0 +1,33 @@
+name: Outrider
+
+# Weekly cron that uses remyxai/outrider to pick a paper from
+# engine.remyx.ai for the FFMPerative research interest and open a draft
+# PR with a Claude-Code-scaffolded integration.
+#
+# Secrets needed (set in Settings → Secrets and variables → Actions):
+#   REMYX_API_KEY     — engine.remyx.ai token
+#   ANTHROPIC_API_KEY — Anthropic console token (for Claude Code)
+#
+# The workflow's built-in GITHUB_TOKEN handles PR / Issue creation on
+# this repo — no PAT required since the action runs in the target.
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'   # Mondays 14:00 UTC
+  workflow_dispatch:
+
+jobs:
+  recommend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    env:
+      REMYX_API_KEY: ${{ secrets.REMYX_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - uses: remyxai/outrider@v1
+        with:
+          interest-id: 6a730cc4-010c-49ce-9c7f-6d9c59431739


### PR DESCRIPTION
## Summary

Installs [Outrider](https://github.com/remyxai/outrider) — a GitHub Action that scouts arXiv weekly for the next paper to integrate into FFMPerative, picks the candidate most implementable against the existing codebase, and opens a draft PR wiring it into an existing call site (or an Issue when a PR would be premature).

## What's set up

- ✅ Research interest configured at engine.remyx.ai (`FFMPerative`, id `6a730cc4-...`)
- ✅ Repo experiment history extracted (9 experiments)
- ✅ \`REMYX_API_KEY\` secret added
- ⏳ \`ANTHROPIC_API_KEY\` secret — still needs to be added before workflow can run

## Schedule

Mondays 14:00 UTC (7am Pacific / 10am Eastern / 3pm London / 9pm Tokyo). \`workflow_dispatch\` also enabled for manual triggering.

## How it works

Each run pulls 25 candidate papers from the past week, Claude picks the most implementable one for FFMPerative specifically (grounded in the repo's commit-history experiment trajectory), then attempts to wire it into an existing call site. Multiple validators (path allowlist, integration check, stub-density, self-review) hold quality.

Expected cost: ~\$2-3 per PR-track run, ~\$2-4/mo at weekly cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)